### PR TITLE
Increase the delta time of concurrent vs simple controller integration tests

### DIFF
--- a/operator/controller/generic_integration_test.go
+++ b/operator/controller/generic_integration_test.go
@@ -27,7 +27,7 @@ const (
 	controllerRunTimeout = 10 * time.Second
 	// this delta is the max duration delta used on the assertion of controller handling, this is required because
 	// the controller requires some millisecond to bootstrap and sync.
-	maxAssertDurationDelta = 200 * time.Millisecond
+	maxAssertDurationDelta = 500 * time.Millisecond
 )
 
 func returnPodList(q int) *corev1.PodList {


### PR DESCRIPTION
This change is due to flakky testing sometimes when we get a slower CI build worker