### PR TITLE
Refactor metrics (Breaking change)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+## 0.x.x / 2018-xx-xx
+
+This release breaks Prometheus metrics interface to allow passing a context (used to allow tracing).
+
+* [ENHANCEMENT] Refactor metrics in favor of less metrics but simpler and more meaningful.
+
 ## 0.3.0 / 2018-07-02
 
 This release breaks handler interface to allow passing a context (used to allow tracing).

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,7 +6,7 @@ Kooper comes with metrics support, this means that when you use kooper to bootst
 
 At this moment these are the supported backends:
 
-* Prometheus.
+- Prometheus.
 
 ## Custom backend
 
@@ -22,22 +22,21 @@ type Recorder interface {
 
 The measured metrics are:
 
-* Number of delete and add queued events (to be processed).
-* Number of delete and add processed successfully events.
-* Number of delete and add processed events with an error.
-* Duration of delete and add processed successfully events.
-* Duration of delete and add processed events with an error.
+- Number of delete and add queued events (to be processed).
+- Number of delete and add processed events.
+- Number of delete and add processed events with an error.
+- Duration of delete and add processed events.
 
 ## How to use the recorder with the controller.
 
-When you create a controller you can pass the metrics recorder that you want. 
+When you create a controller you can pass the metrics recorder that you want.
 **Note: If you pass a `nil` backend, it will not record any metric**
 
 If you want a full example, there is a controller [example][metrics-example] that uses the different metric backends
 
 ### Prometheus
 
-Prometheus backend needs a prometheus [registerer][prometheus-registerer] and a namespace (a prefix for the metircs). 
+Prometheus backend needs a prometheus [registerer][prometheus-registerer] and a namespace (a prefix for the metircs).
 
 For example:
 
@@ -69,7 +68,6 @@ import (
 ```
 
 If you are using the default prometheus methods instead of a custom registry, you could get that from `prometheus.DefaultRegisterer` instead of creating a new registry `reg := prometheus.NewRegistry()`
-
 
 [metrics-interface]: https://github.com/spotahome/kooper/blob/master/monitoring/metrics/metrics.go
 [metrics-example]: https://github.com/spotahome/kooper/tree/master/examples/metrics-controller

--- a/examples/metrics-controller/main.go
+++ b/examples/metrics-controller/main.go
@@ -67,7 +67,7 @@ func createPrometheusRecorder(logger log.Logger) metrics.Recorder {
 	// We could use also prometheus global registry (the default one)
 	// prometheus.DefaultRegisterer instead of creating a new one
 	reg := prometheus.NewRegistry()
-	m := metrics.NewPrometheus(metricsPrefix, reg)
+	m := metrics.NewPrometheus(reg)
 
 	// Start serving metrics in background.
 	h := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
@@ -147,7 +147,10 @@ func main() {
 		log.Errorf("errors getting metrics backend: %s", err)
 		os.Exit(1)
 	}
-	ctrl := controller.NewSequential(30*time.Second, hand, retr, m, log)
+	cfg := &controller.Config{
+		Name: "metricsControllerTest",
+	}
+	ctrl := controller.New(cfg, hand, retr, nil, nil, m, log)
 
 	// Start our controller.
 	stopC := make(chan struct{})

--- a/monitoring/metrics/dummy.go
+++ b/monitoring/metrics/dummy.go
@@ -7,13 +7,11 @@ var Dummy = &dummy{}
 
 type dummy struct{}
 
-func (d *dummy) IncResourceDeleteEventQueued(_ string)                                    {}
-func (d *dummy) IncResourceAddEventQueued(_ string)                                       {}
-func (d *dummy) IncResourceAddEventProcessedSuccess(_ string)                             {}
-func (d *dummy) IncResourceAddEventProcessedError(_ string)                               {}
-func (d *dummy) IncResourceDeleteEventProcessedSuccess(_ string)                          {}
-func (d *dummy) IncResourceDeleteEventProcessedError(_ string)                            {}
-func (d *dummy) ObserveDurationResourceAddEventProcessedSuccess(_ string, _ time.Time)    {}
-func (d *dummy) ObserveDurationResourceAddEventProcessedError(_ string, _ time.Time)      {}
-func (d *dummy) ObserveDurationResourceDeleteEventProcessedSuccess(_ string, _ time.Time) {}
-func (d *dummy) ObserveDurationResourceDeleteEventProcessedError(_ string, _ time.Time)   {}
+func (*dummy) IncResourceEventQueued(_ string, _ EventType) {
+}
+func (*dummy) IncResourceEventProcessed(_ string, _ EventType) {
+}
+func (*dummy) IncResourceEventProcessedError(_ string, _ EventType) {
+}
+func (*dummy) ObserveDurationResourceEventProcessed(_ string, _ EventType, _ time.Time) {
+}

--- a/monitoring/metrics/metrics.go
+++ b/monitoring/metrics/metrics.go
@@ -2,36 +2,24 @@ package metrics
 
 import "time"
 
+// EventType is the event type handled by the controller.
+type EventType string
+
+const (
+	//AddEvent is the add event.
+	AddEvent EventType = "add"
+	// DeleteEvent is the delete event.
+	DeleteEvent EventType = "delete"
+)
+
 // Recorder knows how to record metrics all over the application.
 type Recorder interface {
-	// IncResourceAddEvent increments in one the metric records of a queued add
-	// event in a resource.
-	IncResourceAddEventQueued(handler string)
-	// IncResourceDeleteEvent increments in one the metric records of a queued delete
-	// event in a resource.
-	IncResourceDeleteEventQueued(handler string)
-	// IncResourceAddEventProcessedSuccess increments in one the metric records of a
-	// processed add event in success.
-	IncResourceAddEventProcessedSuccess(handler string)
-	// IncResourceAddEventProcessedError increments in one the metric records of a
-	// processed add event in error.
-	IncResourceAddEventProcessedError(handler string)
-	// IncResourceDeleteEventProcessedSuccess increments in one the metric records of a
-	// processed deleteevent in success.
-	IncResourceDeleteEventProcessedSuccess(handler string)
-	// IncResourceDeleteEventProcessedError increments in one the metric records of a
-	// processed delete event in error.
-	IncResourceDeleteEventProcessedError(handler string)
-	// ObserveDurationResourceAddEventProcessedSuccess measures the duration it took to process
-	// until now a successful processed add event.
-	ObserveDurationResourceAddEventProcessedSuccess(handler string, start time.Time)
-	// ObserveDurationResourceAddEventProcessedError measures the duration it took to process
-	// until now a failed processed add event.
-	ObserveDurationResourceAddEventProcessedError(handler string, start time.Time)
-	// ObserveDurationResourceAddEventProcessedSuccess measures the duration it took to process
-	// until now a successful processed delete event.
-	ObserveDurationResourceDeleteEventProcessedSuccess(handler string, start time.Time)
-	// ObserveDurationResourceAddEventProcessedError measures the duration it took to process
-	// until now a failed processed delete event.
-	ObserveDurationResourceDeleteEventProcessedError(handler string, start time.Time)
+	// IncResourceEvent increments in one the metric records of a queued event.
+	IncResourceEventQueued(controller string, eventType EventType)
+	// IncResourceEventProcessed increments in one the metric records processed event.
+	IncResourceEventProcessed(controller string, eventType EventType)
+	// IncResourceEventProcessedError increments in one the metric records of a processed event in error.
+	IncResourceEventProcessedError(controller string, eventType EventType)
+	// ObserveDurationResourceEventProcessed measures the duration it took to process a event.
+	ObserveDurationResourceEventProcessed(controller string, eventType EventType, start time.Time)
 }

--- a/monitoring/metrics/prometheus_test.go
+++ b/monitoring/metrics/prometheus_test.go
@@ -14,152 +14,99 @@ import (
 )
 
 func TestPrometheusMetrics(t *testing.T) {
-	handler := "handler.Footler"
+	controller := "test"
 
 	tests := []struct {
 		name       string
-		namespace  string
 		addMetrics func(*metrics.Prometheus)
 		expMetrics []string
 		expCode    int
 	}{
 		{
-			name:      "Incrementing different kind of queued events should measure the queued events counter",
-			namespace: "kooper",
+			name: "Incrementing different kind of queued events should measure the queued events counter",
 			addMetrics: func(p *metrics.Prometheus) {
-				p.IncResourceAddEventQueued(handler)
-				p.IncResourceDeleteEventQueued(handler)
-				p.IncResourceAddEventQueued(handler)
-				p.IncResourceAddEventQueued(handler)
-				p.IncResourceDeleteEventQueued(handler)
-				p.IncResourceDeleteEventQueued(handler)
-				p.IncResourceAddEventQueued(handler)
+				p.IncResourceEventQueued(controller, metrics.AddEvent)
+				p.IncResourceEventQueued(controller, metrics.AddEvent)
+				p.IncResourceEventQueued(controller, metrics.AddEvent)
+				p.IncResourceEventQueued(controller, metrics.AddEvent)
+				p.IncResourceEventQueued(controller, metrics.DeleteEvent)
+				p.IncResourceEventQueued(controller, metrics.DeleteEvent)
+				p.IncResourceEventQueued(controller, metrics.DeleteEvent)
 			},
 			expMetrics: []string{
-				`kooper_controller_queued_events_total{handler="handler.Footler",type="add"} 4`,
-				`kooper_controller_queued_events_total{handler="handler.Footler",type="delete"} 3`,
+				`kooper_controller_queued_events_total{controller="test",type="add"} 4`,
+				`kooper_controller_queued_events_total{controller="test",type="delete"} 3`,
 			},
 			expCode: 200,
 		},
 		{
-			name:      "Incrementing different kind of processed events should measure the queued events counter",
-			namespace: "batman",
+			name: "Incrementing different kind of processed events should measure the processed events counter",
 			addMetrics: func(p *metrics.Prometheus) {
-				p.IncResourceAddEventProcessedSuccess(handler)
-				p.IncResourceAddEventProcessedError(handler)
-				p.IncResourceAddEventProcessedError(handler)
-				p.IncResourceDeleteEventProcessedSuccess(handler)
-				p.IncResourceDeleteEventProcessedSuccess(handler)
-				p.IncResourceDeleteEventProcessedSuccess(handler)
-				p.IncResourceDeleteEventProcessedError(handler)
-				p.IncResourceDeleteEventProcessedError(handler)
-				p.IncResourceDeleteEventProcessedError(handler)
-				p.IncResourceDeleteEventProcessedError(handler)
+				p.IncResourceEventProcessed(controller, metrics.AddEvent)
+				p.IncResourceEventProcessedError(controller, metrics.AddEvent)
+				p.IncResourceEventProcessedError(controller, metrics.AddEvent)
+				p.IncResourceEventProcessed(controller, metrics.DeleteEvent)
+				p.IncResourceEventProcessed(controller, metrics.DeleteEvent)
+				p.IncResourceEventProcessed(controller, metrics.DeleteEvent)
+				p.IncResourceEventProcessedError(controller, metrics.DeleteEvent)
+				p.IncResourceEventProcessedError(controller, metrics.DeleteEvent)
+				p.IncResourceEventProcessedError(controller, metrics.DeleteEvent)
+				p.IncResourceEventProcessedError(controller, metrics.DeleteEvent)
 
 			},
 			expMetrics: []string{
-				`batman_controller_processed_events_total{handler="handler.Footler",type="add"} 1`,
-				`batman_controller_processed_events_errors_total{handler="handler.Footler",type="add"} 2`,
-				`batman_controller_processed_events_total{handler="handler.Footler",type="delete"} 3`,
-				`batman_controller_processed_events_errors_total{handler="handler.Footler",type="delete"} 4`,
+				`kooper_controller_processed_events_total{controller="test",type="add"} 1`,
+				`kooper_controller_processed_event_errors_total{controller="test",type="add"} 2`,
+				`kooper_controller_processed_events_total{controller="test",type="delete"} 3`,
+				`kooper_controller_processed_event_errors_total{controller="test",type="delete"} 4`,
 			},
 			expCode: 200,
 		},
 		{
-			name:      "Measuring the duration of processed Add events return the correct buckets.",
-			namespace: "spiderman",
+			name: "Measuring the duration of processed events return the correct buckets.",
 			addMetrics: func(p *metrics.Prometheus) {
 				now := time.Now()
-				p.ObserveDurationResourceAddEventProcessedError(handler, now.Add(-2*time.Millisecond))
-				p.ObserveDurationResourceAddEventProcessedError(handler, now.Add(-3*time.Millisecond))
-				p.ObserveDurationResourceAddEventProcessedError(handler, now.Add(-11*time.Millisecond))
-				p.ObserveDurationResourceAddEventProcessedError(handler, now.Add(-280*time.Millisecond))
-				p.ObserveDurationResourceAddEventProcessedError(handler, now.Add(-1*time.Second))
-				p.ObserveDurationResourceAddEventProcessedError(handler, now.Add(-5*time.Second))
-				p.ObserveDurationResourceAddEventProcessedSuccess(handler, now.Add(-110*time.Millisecond))
-				p.ObserveDurationResourceAddEventProcessedSuccess(handler, now.Add(-560*time.Millisecond))
-				p.ObserveDurationResourceAddEventProcessedSuccess(handler, now.Add(-4*time.Second))
-				p.ObserveDurationResourceAddEventProcessedSuccess(handler, now.Add(-7*time.Second))
-				p.ObserveDurationResourceAddEventProcessedSuccess(handler, now.Add(-12*time.Second))
-				p.ObserveDurationResourceAddEventProcessedSuccess(handler, now.Add(-30*time.Second))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.AddEvent, now.Add(-2*time.Millisecond))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.AddEvent, now.Add(-3*time.Millisecond))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.AddEvent, now.Add(-11*time.Millisecond))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.AddEvent, now.Add(-280*time.Millisecond))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.AddEvent, now.Add(-1*time.Second))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.AddEvent, now.Add(-5*time.Second))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.DeleteEvent, now.Add(-110*time.Millisecond))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.DeleteEvent, now.Add(-560*time.Millisecond))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.DeleteEvent, now.Add(-4*time.Second))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.DeleteEvent, now.Add(-7*time.Second))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.DeleteEvent, now.Add(-12*time.Second))
+				p.ObserveDurationResourceEventProcessed(controller, metrics.DeleteEvent, now.Add(-30*time.Second))
 			},
 			expMetrics: []string{
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.005"} 2`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.01"} 2`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.025"} 3`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.05"} 3`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.1"} 3`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.25"} 3`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.5"} 4`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="1"} 4`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="2.5"} 5`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="5"} 5`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="10"} 6`,
-				`spiderman_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="add",le="+Inf"} 6`,
-				`spiderman_controller_processed_events_error_duration_seconds_count{handler="handler.Footler",type="add"} 6`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.005"} 2`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.01"} 2`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.025"} 3`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.05"} 3`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.1"} 3`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.25"} 3`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.5"} 4`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="1"} 4`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="2.5"} 5`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="5"} 5`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="10"} 6`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="+Inf"} 6`,
+				`kooper_controller_processed_event_duration_seconds_count{controller="test",type="add"} 6`,
 
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.005"} 0`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.01"} 0`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.025"} 0`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.05"} 0`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.1"} 0`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.25"} 1`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="0.5"} 1`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="1"} 2`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="2.5"} 2`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="5"} 3`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="10"} 4`,
-				`spiderman_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="add",le="+Inf"} 6`,
-				`spiderman_controller_processed_events_duration_seconds_count{handler="handler.Footler",type="add"} 6`,
-			},
-			expCode: 200,
-		},
-		{
-			name:      "Measuring the duration of processed Delete events return the correct buckets.",
-			namespace: "deadpool",
-			addMetrics: func(p *metrics.Prometheus) {
-				now := time.Now()
-				p.ObserveDurationResourceDeleteEventProcessedError(handler, now.Add(-3*time.Millisecond))
-				p.ObserveDurationResourceDeleteEventProcessedError(handler, now.Add(-2*time.Millisecond))
-				p.ObserveDurationResourceDeleteEventProcessedError(handler, now.Add(-11*time.Millisecond))
-				p.ObserveDurationResourceDeleteEventProcessedError(handler, now.Add(-280*time.Millisecond))
-				p.ObserveDurationResourceDeleteEventProcessedError(handler, now.Add(-1*time.Second))
-				p.ObserveDurationResourceDeleteEventProcessedError(handler, now.Add(-5*time.Second))
-				p.ObserveDurationResourceDeleteEventProcessedSuccess(handler, now.Add(-110*time.Millisecond))
-				p.ObserveDurationResourceDeleteEventProcessedSuccess(handler, now.Add(-560*time.Millisecond))
-				p.ObserveDurationResourceDeleteEventProcessedSuccess(handler, now.Add(-4*time.Second))
-				p.ObserveDurationResourceDeleteEventProcessedSuccess(handler, now.Add(-7*time.Second))
-				p.ObserveDurationResourceDeleteEventProcessedSuccess(handler, now.Add(-12*time.Second))
-				p.ObserveDurationResourceDeleteEventProcessedSuccess(handler, now.Add(-30*time.Second))
-			},
-			expMetrics: []string{
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.005"} 2`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.01"} 2`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.025"} 3`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.05"} 3`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.1"} 3`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.25"} 3`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.5"} 4`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="1"} 4`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="2.5"} 5`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="5"} 5`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="10"} 6`,
-				`deadpool_controller_processed_events_error_duration_seconds_bucket{handler="handler.Footler",type="delete",le="+Inf"} 6`,
-				`deadpool_controller_processed_events_error_duration_seconds_count{handler="handler.Footler",type="delete"} 6`,
-
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.005"} 0`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.01"} 0`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.025"} 0`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.05"} 0`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.1"} 0`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.25"} 1`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="0.5"} 1`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="1"} 2`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="2.5"} 2`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="5"} 3`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="10"} 4`,
-				`deadpool_controller_processed_events_duration_seconds_bucket{handler="handler.Footler",type="delete",le="+Inf"} 6`,
-				`deadpool_controller_processed_events_duration_seconds_count{handler="handler.Footler",type="delete"} 6`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="0.005"} 0`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="0.01"} 0`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="0.025"} 0`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="0.05"} 0`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="0.1"} 0`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="0.25"} 1`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="0.5"} 1`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="1"} 2`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="2.5"} 2`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="5"} 3`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="10"} 4`,
+				`kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="delete",le="+Inf"} 6`,
+				`kooper_controller_processed_event_duration_seconds_count{controller="test",type="delete"} 6`,
 			},
 			expCode: 200,
 		},
@@ -171,7 +118,7 @@ func TestPrometheusMetrics(t *testing.T) {
 
 			// Create a new prometheus empty registry and a kooper prometheus recorder.
 			reg := prometheus.NewRegistry()
-			m := metrics.NewPrometheus(test.namespace, reg)
+			m := metrics.NewPrometheus(reg)
 
 			// Add desired metrics
 			test.addMetrics(m)

--- a/operator/controller/config.go
+++ b/operator/controller/config.go
@@ -7,7 +7,6 @@ const (
 	defResyncInterval       = 30 * time.Second
 	defConcurrentWorkers    = 1
 	defProcessingJobRetries = 3
-	defControllerName       = "controller"
 )
 
 // Config is the controller configuration.
@@ -33,9 +32,5 @@ func (c *Config) setDefaults() {
 
 	if c.ProcessingJobRetries <= 0 {
 		c.ProcessingJobRetries = defProcessingJobRetries
-	}
-
-	if c.Name == "" {
-		c.Name = defControllerName
 	}
 }

--- a/operator/controller/generic.go
+++ b/operator/controller/generic.go
@@ -100,7 +100,7 @@ func New(cfg *Config, handler handler.Handler, retriever retrieve.Retriever, lea
 		tracer = &opentracing.NoopTracer{}
 	}
 
-	// Get a handler name for the metrics based on the type of the handler.
+	// If no name on controller do our best to infer a name based on the handler.
 	if cfg.Name == "" {
 		cfg.Name = reflect.TypeOf(handler).String()
 		logger.Warningf("controller name not provided, it should have a name, fallback name to: %s", cfg.Name)

--- a/operator/controller/generic.go
+++ b/operator/controller/generic.go
@@ -42,17 +42,16 @@ const (
 
 // generic controller is a controller that can be used to create different kind of controllers.
 type generic struct {
-	queue       workqueue.RateLimitingInterface // queue will have the jobs that the controller will get and send to handlers.
-	informer    cache.SharedIndexInformer       // informer will notify be inform us about resource changes.
-	handler     handler.Handler                 // handler is where the logic of resource processing.
-	handlerName string                          // handlerName will be used to identify and give more insight about metrics.
-	running     bool
-	runningMu   sync.Mutex
-	cfg         Config
-	tracer      opentracing.Tracer // use directly opentracing API because it's not an implementation.
-	metrics     metrics.Recorder
-	leRunner    leaderelection.Runner
-	logger      log.Logger
+	queue     workqueue.RateLimitingInterface // queue will have the jobs that the controller will get and send to handlers.
+	informer  cache.SharedIndexInformer       // informer will notify be inform us about resource changes.
+	handler   handler.Handler                 // handler is where the logic of resource processing.
+	running   bool
+	runningMu sync.Mutex
+	cfg       Config
+	tracer    opentracing.Tracer // use directly opentracing API because it's not an implementation.
+	metrics   metrics.Recorder
+	leRunner  leaderelection.Runner
+	logger    log.Logger
 }
 
 // NewSequential creates a new controller that will process the received events sequentially.
@@ -102,7 +101,10 @@ func New(cfg *Config, handler handler.Handler, retriever retrieve.Retriever, lea
 	}
 
 	// Get a handler name for the metrics based on the type of the handler.
-	handlerName := reflect.TypeOf(handler).String()
+	if cfg.Name == "" {
+		cfg.Name = reflect.TypeOf(handler).String()
+		logger.Warningf("controller name not provided, it should have a name, fallback name to: %s", cfg.Name)
+	}
 
 	// Create the queue that will have our received job changes. It's rate limited so we don't have problems when
 	// a job processing errors every time is processed in a loop.
@@ -120,36 +122,35 @@ func New(cfg *Config, handler handler.Handler, retriever retrieve.Retriever, lea
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
 				queue.Add(key)
-				metricRecorder.IncResourceAddEventQueued(handlerName)
+				metricRecorder.IncResourceEventQueued(cfg.Name, metrics.AddEvent)
 			}
 		},
 		UpdateFunc: func(old interface{}, new interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(new)
 			if err == nil {
 				queue.Add(key)
-				metricRecorder.IncResourceAddEventQueued(handlerName)
+				metricRecorder.IncResourceEventQueued(cfg.Name, metrics.AddEvent)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err == nil {
 				queue.Add(key)
-				metricRecorder.IncResourceDeleteEventQueued(handlerName)
+				metricRecorder.IncResourceEventQueued(cfg.Name, metrics.DeleteEvent)
 			}
 		},
 	}, cfg.ResyncInterval)
 
 	// Create our generic controller object.
 	return &generic{
-		queue:       queue,
-		informer:    informer,
-		logger:      logger,
-		metrics:     metricRecorder,
-		tracer:      tracer,
-		handler:     handler,
-		handlerName: handlerName,
-		leRunner:    leaderElector,
-		cfg:         *cfg,
+		queue:    queue,
+		informer: informer,
+		logger:   logger,
+		metrics:  metricRecorder,
+		tracer:   tracer,
+		handler:  handler,
+		leRunner: leaderElector,
+		cfg:      *cfg,
 	}
 }
 
@@ -279,6 +280,10 @@ func (g *generic) processJob(ctx context.Context, key string) error {
 
 func (g *generic) handleAdd(ctx context.Context, objKey string, obj runtime.Object) error {
 	start := time.Now()
+	g.metrics.IncResourceEventProcessed(g.cfg.Name, metrics.AddEvent)
+	defer func() {
+		g.metrics.ObserveDurationResourceEventProcessed(g.cfg.Name, metrics.AddEvent, start)
+	}()
 
 	// Create the span.
 	pSpan := opentracing.SpanFromContext(ctx)
@@ -303,17 +308,18 @@ func (g *generic) handleAdd(ctx context.Context, objKey string, obj runtime.Obje
 			messageKey, err,
 		)
 
-		g.metrics.IncResourceAddEventProcessedError(g.handlerName)
-		g.metrics.ObserveDurationResourceAddEventProcessedError(g.handlerName, start)
+		g.metrics.IncResourceEventProcessedError(g.cfg.Name, metrics.AddEvent)
 		return err
 	}
-	g.metrics.IncResourceAddEventProcessedSuccess(g.handlerName)
-	g.metrics.ObserveDurationResourceAddEventProcessedSuccess(g.handlerName, start)
 	return nil
 }
 
 func (g *generic) handleDelete(ctx context.Context, objKey string) error {
 	start := time.Now()
+	g.metrics.IncResourceEventProcessed(g.cfg.Name, metrics.DeleteEvent)
+	defer func() {
+		g.metrics.ObserveDurationResourceEventProcessed(g.cfg.Name, metrics.DeleteEvent, start)
+	}()
 
 	// Create the span.
 	pSpan := opentracing.SpanFromContext(ctx)
@@ -338,12 +344,9 @@ func (g *generic) handleDelete(ctx context.Context, objKey string) error {
 			messageKey, err,
 		)
 
-		g.metrics.IncResourceDeleteEventProcessedError(g.handlerName)
-		g.metrics.ObserveDurationResourceDeleteEventProcessedError(g.handlerName, start)
+		g.metrics.IncResourceEventProcessedError(g.cfg.Name, metrics.DeleteEvent)
 		return err
 	}
-	g.metrics.IncResourceDeleteEventProcessedSuccess(g.handlerName)
-	g.metrics.ObserveDurationResourceDeleteEventProcessedSuccess(g.handlerName, start)
 	return nil
 }
 


### PR DESCRIPTION
**Breaks prometheus metrics in favor of less metrics but simpler and more meaningful ones.**

This PR refactors all the metrics with a simple API.

Prometheus metrics now follow better standards. Now all kooper metrics have `kooper` as the namespace and the systems using kooper should query the different services (that use kooper) by labels like `service` or/and `job` (Dynamic metric naming it's a smell that should be in a label).

New example metrics:
```
kooper_controller_queued_events_total{controller="test",type="add"} 10

kooper_controller_processed_events_total{controller="test",type="add"} 6
kooper_controller_processed_events_total{controller="test",type="delete"} 3
kooper_controller_processed_event_errors_total{controller="test",type="delete"} 4

kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.005"} 2
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.01"} 2
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.025"} 3
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.05"} 3
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.1"} 3
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.25"} 3
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="0.5"} 4
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="1"} 4
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="2.5"} 5
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="5"} 5
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="10"} 6
kooper_controller_processed_event_duration_seconds_bucket{controller="test",type="add",le="+Inf"} 6
kooper_controller_processed_event_duration_seconds_count{controller="test",type="add"} 6
```
