### PR TITLE
Add CRD client subresources support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 ## 0.x.x / 2018-xx-xx
 
+* [FEATURE] Add enable subresources support on CRD registration.
 * [FEATURE] Add category support on CRD registration.
 
 ## 0.4.0 / 2018-07-21


### PR DESCRIPTION
Since Kubernetes v1.10, CRD subresource can be used, this PR adds the CRD client the ability to enable subresources on creation (status and scale).