### PR TITLE
[POC] Expose hasSynced and event.kind to domain logic

### DIFF
--- a/examples/onefile-echo-pod-controller/main.go
+++ b/examples/onefile-echo-pod-controller/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spotahome/kooper/operator/controller"
 	"github.com/spotahome/kooper/operator/handler"
 	"github.com/spotahome/kooper/operator/retrieve"
+	"github.com/spotahome/kooper/operator/common"
 )
 
 func main() {
@@ -59,13 +60,13 @@ func main() {
 
 	// Our domain logic that will print every add/sync/update and delete event we .
 	hand := &handler.HandlerFunc{
-		AddFunc: func(_ context.Context, obj runtime.Object) error {
-			pod := obj.(*corev1.Pod)
-			log.Infof("Pod added: %s/%s", pod.Namespace, pod.Name)
+		AddFunc: func(_ context.Context, evt *common.K8sEvent) error {
+			pod := evt.Object.(*corev1.Pod)
+			log.Infof("Pod added: %s/%s %v", pod.Namespace, pod.Name, evt.HasSynced)
 			return nil
 		},
-		DeleteFunc: func(_ context.Context, s string) error {
-			log.Infof("Pod deleted: %s", s)
+		DeleteFunc: func(_ context.Context, evt *common.K8sEvent) error {
+			log.Infof("Pod deleted: %s", evt.Key)
 			return nil
 		},
 	}

--- a/operator/common/common.go
+++ b/operator/common/common.go
@@ -1,0 +1,11 @@
+package common
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+// K8sEvent represents the k8s events coming from the informer
+type K8sEvent struct {
+	Key       string
+	HasSynced bool
+	Object    runtime.Object
+	Kind      string
+}

--- a/operator/controller/generic.go
+++ b/operator/controller/generic.go
@@ -250,17 +250,17 @@ func (g *generic) getAndProcessNextJob() bool {
 
 	// Process the job. If errors then enqueue again.
 	if err := g.processJob(ctx, evt); err == nil {
-		g.queue.Forget(evt.Key)
+		g.queue.Forget(evt)
 		g.setForgetSpanInfo(evt.Key, span, err)
-	} else if g.queue.NumRequeues(evt.Key) < g.cfg.ProcessingJobRetries {
+	} else if g.queue.NumRequeues(evt) < g.cfg.ProcessingJobRetries {
 		// Job processing failed, requeue.
 		g.logger.Warningf("error processing %s job (requeued): %v", evt.Key, err)
-		g.queue.AddRateLimited(evt.Key)
+		g.queue.AddRateLimited(evt)
 		g.metrics.IncResourceEventQueued(g.cfg.Name, metrics.RequeueEvent)
 		g.setReenqueueSpanInfo(evt.Key, span, err)
 	} else {
 		g.logger.Errorf("Error processing %s: %v", evt.Key, err)
-		g.queue.Forget(evt.Key)
+		g.queue.Forget(evt)
 		g.setForgetSpanInfo(evt.Key, span, err)
 	}
 

--- a/operator/handler/handler.go
+++ b/operator/handler/handler.go
@@ -4,20 +4,20 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime"
+	"github.com/spotahome/kooper/operator/common"
 )
 
 // Handler knows how to handle the received resources from a kubernetes cluster.
 type Handler interface {
-	Add(context.Context, runtime.Object) error
-	Delete(context.Context, string) error
+	Add(context.Context, *common.K8sEvent) error
+	Delete(context.Context, *common.K8sEvent) error
 }
 
 // AddFunc knows how to handle resource adds.
-type AddFunc func(context.Context, runtime.Object) error
+type AddFunc func(context.Context, *common.K8sEvent) error
 
 // DeleteFunc knows how to handle resource deletes.
-type DeleteFunc func(context.Context, string) error
+type DeleteFunc func(context.Context, *common.K8sEvent) error
 
 // HandlerFunc is a handler that is created from functions that the
 // Handler interface requires.
@@ -27,17 +27,17 @@ type HandlerFunc struct {
 }
 
 // Add satisfies Handler interface.
-func (h *HandlerFunc) Add(ctx context.Context, obj runtime.Object) error {
+func (h *HandlerFunc) Add(ctx context.Context, evt *common.K8sEvent) error {
 	if h.AddFunc == nil {
 		return fmt.Errorf("function can't be nil")
 	}
-	return h.AddFunc(ctx, obj)
+	return h.AddFunc(ctx, evt)
 }
 
 // Delete satisfies Handler interface.
-func (h *HandlerFunc) Delete(ctx context.Context, s string) error {
+func (h *HandlerFunc) Delete(ctx context.Context, evt *common.K8sEvent) error {
 	if h.DeleteFunc == nil {
 		return fmt.Errorf("function can't be nil")
 	}
-	return h.DeleteFunc(ctx, s)
+	return h.DeleteFunc(ctx, evt)
 }


### PR DESCRIPTION
Hi,
I'm working into a project called [kwatchman](https://github.com/snebel29/kwatchman) that uses kubernetes controller "machinery" to watch for resources changes and notify on manifest changes differences.

I would really like to use `kooper` to avoid reinventing the wheel, and because I like this package, it's clean and nice I have to say, however I'm missing a key feature for my project, exposing `informer.HasSynced()` and `event.kind` into the domain logic so I can avoid triggering notifications with the first batch but at the same time I can store them in an internal map, for future comparisons.

I've implemented a proof of concept in this PR, to try and see if this might get a change to be merged, if I'm lucky enough to get :thumbsup: I would finish this pull request up properly by adding and fixing tests, updating examples, and any other requirement coming from the authors.

If this is rejected, because does not fully fit the goals of the framework or whatever other reason, I think I will fork the library and integrate in my project anyway, because It's cool 😄

Fantástico trabajo!
Firmado: Un Madrileño con nombre vikingo, viviendo en Dublin

Un saludo
