### PR TITLE
fix invalid pseudo version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	k8s.io/api v0.0.0-20190222213804-5cb15d344471
 	k8s.io/apiextensions-apiserver v0.0.0-20190508191920-007dc40467c5
 	k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
-	k8s.io/client-go v2.0.0-alpha.0.0.20190507014756-65905f29c17c+incompatible
+	k8s.io/client-go v0.0.0-20190507014756-65905f29c17c
 	k8s.io/klog v0.3.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20180420230433-1e45fb05b063 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ k8s.io/apiextensions-apiserver v0.0.0-20190508191920-007dc40467c5 h1:jCLloa8f3xs
 k8s.io/apiextensions-apiserver v0.0.0-20190508191920-007dc40467c5/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
 k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628 h1:UYfHH+KEF88OTg+GojQUwFTNxbxwmoktLwutUzR0GPg=
 k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/client-go v2.0.0-alpha.0.0.20190507014756-65905f29c17c+incompatible h1:/UyefDqrvdRTMbkvPItAt1aNEDTcB1UDsuloh6NUJXM=
-k8s.io/client-go v2.0.0-alpha.0.0.20190507014756-65905f29c17c+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
+k8s.io/client-go v0.0.0-20190507014756-65905f29c17c h1:xVGTXUtdBHoqT17arGVxOQTEpBze9eCmwlqjNZA4z7k=
+k8s.io/client-go v0.0.0-20190507014756-65905f29c17c/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.3.2 h1:qvP/U6CcZ6qyi/qSHlJKdlAboCzo3mT0DAm0XAarpz4=
 k8s.io/klog v0.3.2/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/kube-openapi v0.0.0-20180420230433-1e45fb05b063 h1:E7opvbPzeUhC2yuCj4NVWlvHPFz9wm/LmS+UAlweN4c=


### PR DESCRIPTION
Hi,

Remember my comment on #74 ? 
This actually breaks today 🙂 

From the Go 1.13 Release Notes:

> The go command now verifies the mapping between pseudo-versions and version-control metadata. 

https://golang.org/doc/go1.13 (version validation)

This means when trying to build a program with kooper as a depedency, go will complain:

```
go: github.com/spotahome/kooper@v0.6.1-0.20190601085127-bb50a407ffa9 requires
        k8s.io/client-go@v2.0.0-alpha.0.0.20190507014756-65905f29c17c+incompatible: invalid pseudo-version: preceding tag (v2.0.0-alpha.0) not found
```

So I followed the instructions on the release notes, I removed the version info and left only the commit hash, and ran go build.
I also did: instead of specifying the commit hash, I used `kubernetes-1.13.6`.
This gets resolved to the exact same commit and the exact same version information in `go.mod`.
