### PR TITLE
Remove Delete event concept from Kooper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ NOTE: Breaking release in controllers.
 - Add multiretriever to retriever different resource types on the same controller.
 - Refactor metrics recorder implementation including the prometheus backend.
 - Refactor internal controller queue into a decorator implementation approach.
+- Remove `Delete` method from `controller.Handler` and simplify to only `Handle` method
 
 ## [0.8.0] - 2019-12-11
 

--- a/controller/handler.go
+++ b/controller/handler.go
@@ -9,35 +9,16 @@ import (
 
 // Handler knows how to handle the received resources from a kubernetes cluster.
 type Handler interface {
-	Add(context.Context, runtime.Object) error
-	Delete(context.Context, string) error
+	Handle(context.Context, runtime.Object) error
 }
 
-// AddFunc knows how to handle resource adds.
-type AddFunc func(context.Context, runtime.Object) error
+// HandlerFunc knows how to handle resource adds.
+type HandlerFunc func(context.Context, runtime.Object) error
 
-// DeleteFunc knows how to handle resource deletes.
-type DeleteFunc func(context.Context, string) error
-
-// HandlerFunc is a handler that is created from functions that the
-// Handler interface requires.
-type HandlerFunc struct {
-	AddFunc    AddFunc
-	DeleteFunc DeleteFunc
-}
-
-// Add satisfies Handler interface.
-func (h *HandlerFunc) Add(ctx context.Context, obj runtime.Object) error {
-	if h.AddFunc == nil {
-		return fmt.Errorf("function can't be nil")
+// Handle satisfies controller.Handler interface.
+func (h HandlerFunc) Handle(ctx context.Context, obj runtime.Object) error {
+	if h == nil {
+		return fmt.Errorf("handle func is required")
 	}
-	return h.AddFunc(ctx, obj)
-}
-
-// Delete satisfies Handler interface.
-func (h *HandlerFunc) Delete(ctx context.Context, s string) error {
-	if h.DeleteFunc == nil {
-		return fmt.Errorf("function can't be nil")
-	}
-	return h.DeleteFunc(ctx, s)
+	return h(ctx, obj)
 }

--- a/controller/processor.go
+++ b/controller/processor.go
@@ -32,12 +32,11 @@ func newIndexerProcessor(indexer cache.Indexer, handler Handler) processor {
 			return err
 		}
 
-		// Handle the object.
 		if !exists {
-			return handler.Delete(ctx, key)
+			return nil
 		}
 
-		return handler.Add(ctx, obj.(runtime.Object))
+		return handler.Handle(ctx, obj.(runtime.Object))
 	})
 }
 

--- a/examples/config-custom-controller/main.go
+++ b/examples/config-custom-controller/main.go
@@ -55,17 +55,11 @@ func run() error {
 	})
 
 	// Our domain logic that will print every add/sync/update and delete event we .
-	hand := &controller.HandlerFunc{
-		AddFunc: func(_ context.Context, obj runtime.Object) error {
-			pod := obj.(*corev1.Pod)
-			logger.Infof("Pod added: %s/%s", pod.Namespace, pod.Name)
-			return nil
-		},
-		DeleteFunc: func(_ context.Context, s string) error {
-			logger.Infof("Pod deleted: %s", s)
-			return nil
-		},
-	}
+	hand := controller.HandlerFunc(func(_ context.Context, obj runtime.Object) error {
+		pod := obj.(*corev1.Pod)
+		logger.Infof("Pod added: %s/%s", pod.Namespace, pod.Name)
+		return nil
+	})
 
 	// Create the controller with custom configuration.
 	cfg := &controller.Config{

--- a/examples/controller-concurrency-handling/main.go
+++ b/examples/controller-concurrency-handling/main.go
@@ -102,19 +102,12 @@ func run() error {
 	})
 
 	// Our domain logic that will print every add/sync/update and delete event we.
-	hand := &controller.HandlerFunc{
-		AddFunc: func(_ context.Context, obj runtime.Object) error {
-			pod := obj.(*corev1.Pod)
-			sleep()
-			logger.Infof("Pod added: %s/%s", pod.Namespace, pod.Name)
-			return nil
-		},
-		DeleteFunc: func(_ context.Context, s string) error {
-			sleep()
-			logger.Infof("Pod deleted: %s", s)
-			return nil
-		},
-	}
+	hand := controller.HandlerFunc(func(_ context.Context, obj runtime.Object) error {
+		pod := obj.(*corev1.Pod)
+		sleep()
+		logger.Infof("Pod added: %s/%s", pod.Namespace, pod.Name)
+		return nil
+	})
 
 	// Create the controller.
 	cfg := &controller.Config{

--- a/examples/leader-election-controller/main.go
+++ b/examples/leader-election-controller/main.go
@@ -87,17 +87,11 @@ func run() error {
 	})
 
 	// Our domain logic that will print every add/sync/update and delete event we .
-	hand := &controller.HandlerFunc{
-		AddFunc: func(_ context.Context, obj runtime.Object) error {
-			pod := obj.(*corev1.Pod)
-			logger.Infof("Pod added: %s/%s", pod.Namespace, pod.Name)
-			return nil
-		},
-		DeleteFunc: func(_ context.Context, s string) error {
-			logger.Infof("Pod deleted: %s", s)
-			return nil
-		},
-	}
+	hand := controller.HandlerFunc(func(_ context.Context, obj runtime.Object) error {
+		pod := obj.(*corev1.Pod)
+		logger.Infof("Pod added: %s/%s", pod.Namespace, pod.Name)
+		return nil
+	})
 
 	// Leader election service.
 	lesvc, err := leaderelection.NewDefault(leaderElectionKey, fl.Namespace, k8scli, logger)

--- a/examples/metrics-controller/main.go
+++ b/examples/metrics-controller/main.go
@@ -114,16 +114,10 @@ func run() error {
 	})
 
 	// Our domain logic that will print every add/sync/update and delete event we .
-	hand := &controller.HandlerFunc{
-		AddFunc: func(_ context.Context, obj runtime.Object) error {
-			sleepRandomly()
-			return errRandomly()
-		},
-		DeleteFunc: func(_ context.Context, s string) error {
-			sleepRandomly()
-			return errRandomly()
-		},
-	}
+	hand := controller.HandlerFunc(func(_ context.Context, obj runtime.Object) error {
+		sleepRandomly()
+		return errRandomly()
+	})
 
 	// Create the controller that will refresh every 30 seconds.
 	cfg := &controller.Config{

--- a/examples/multi-resource-controller/main.go
+++ b/examples/multi-resource-controller/main.go
@@ -73,26 +73,21 @@ func run() error {
 	}
 
 	// Our domain logic that will print every add/sync/update and delete event we .
-	hand := &controller.HandlerFunc{
-		AddFunc: func(_ context.Context, obj runtime.Object) error {
-			dep, ok := obj.(*appsv1.Deployment)
-			if ok {
-				logger.Infof("Deployment added: %s/%s", dep.Namespace, dep.Name)
-				return nil
-			}
-
-			st, ok := obj.(*appsv1.StatefulSet)
-			if ok {
-				logger.Infof("Statefulset added: %s/%s", st.Namespace, st.Name)
-				return nil
-			}
-
+	hand := controller.HandlerFunc(func(_ context.Context, obj runtime.Object) error {
+		dep, ok := obj.(*appsv1.Deployment)
+		if ok {
+			logger.Infof("Deployment added: %s/%s", dep.Namespace, dep.Name)
 			return nil
-		},
-		DeleteFunc: func(_ context.Context, s string) error {
+		}
+
+		st, ok := obj.(*appsv1.StatefulSet)
+		if ok {
+			logger.Infof("Statefulset added: %s/%s", st.Namespace, st.Name)
 			return nil
-		},
-	}
+		}
+
+		return nil
+	})
 
 	// Create the controller with custom configuration.
 	cfg := &controller.Config{

--- a/examples/pod-terminator-operator/apis/chaos/v1alpha1/types.go
+++ b/examples/pod-terminator-operator/apis/chaos/v1alpha1/types.go
@@ -4,11 +4,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// PodTerminator represents a pod terminator.
+//
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// PodTerminator represents a pod terminator.
+// +kubebuilder:resource:singular=podterminator,path=podterminators,shortName=pt,scope=Cluster,categories=terminators;killers;gc
 type PodTerminator struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/examples/pod-terminator-operator/manifest-examples/pause.yaml
+++ b/examples/pod-terminator-operator/manifest-examples/pause.yaml
@@ -1,7 +1,8 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pause-pods
+  namespace: kooper-test
   labels:
     application: pause
 spec:

--- a/examples/pod-terminator-operator/manifests/chaos.spotahome.com_podterminators.yaml
+++ b/examples/pod-terminator-operator/manifests/chaos.spotahome.com_podterminators.yaml
@@ -10,11 +10,17 @@ metadata:
 spec:
   group: chaos.spotahome.com
   names:
+    categories:
+    - terminators
+    - killers
+    - gc
     kind: PodTerminator
     listKind: PodTerminatorList
     plural: podterminators
+    shortNames:
+    - pt
     singular: podterminator
-  scope: Namespaced
+  scope: Cluster
   validation:
     openAPIV3Schema:
       description: PodTerminator represents a pod terminator.

--- a/examples/pod-terminator-operator/service/chaos/chaos.go
+++ b/examples/pod-terminator-operator/service/chaos/chaos.go
@@ -59,7 +59,6 @@ func (c *Chaos) EnsurePodTerminator(pt *chaosv1alpha1.PodTerminator) error {
 	pk = NewPodKiller(ptCopy, c.k8sCli, c.logger)
 	c.reg.Store(pt.Name, pk)
 	return pk.Start()
-	// TODO: garbage collection.
 }
 
 // DeletePodTerminator satisfies ChaosSyncer interface.

--- a/mocks/controller/Handler.go
+++ b/mocks/controller/Handler.go
@@ -15,26 +15,12 @@ type Handler struct {
 	mock.Mock
 }
 
-// Add provides a mock function with given fields: _a0, _a1
-func (_m *Handler) Add(_a0 context.Context, _a1 runtime.Object) error {
+// Handle provides a mock function with given fields: _a0, _a1
+func (_m *Handler) Handle(_a0 context.Context, _a1 runtime.Object) error {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, runtime.Object) error); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// Delete provides a mock function with given fields: _a0, _a1
-func (_m *Handler) Delete(_a0 context.Context, _a1 string) error {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Error(0)

--- a/test/integration/controller/generic_test.go
+++ b/test/integration/controller/generic_test.go
@@ -64,17 +64,11 @@ func runTimedController(sleepDuration time.Duration, concurrencyLevel int, numbe
 	var wg sync.WaitGroup
 	wg.Add(numberOfEvents)
 
-	h := &controller.HandlerFunc{
-		AddFunc: func(_ context.Context, _ runtime.Object) error {
-			time.Sleep(sleepDuration)
-			wg.Done()
-			return nil
-		},
-		DeleteFunc: func(_ context.Context, _ string) error {
-			assert.Fail("delete events should not be used on this test")
-			return nil
-		},
-	}
+	h := controller.HandlerFunc(func(_ context.Context, _ runtime.Object) error {
+		time.Sleep(sleepDuration)
+		wg.Done()
+		return nil
+	})
 
 	// Create the controller type depending on the concurrency level.
 	cfg := &controller.Config{


### PR DESCRIPTION
This PR removes the concept of delete event from Kooper.

Deletion event reception can't be guaranteed, this is because The controller can be down/restarting or have a networking issue and the deletion event will never reach the controller. **This means that the delete event is not reliable.**

We prefer not having an event that can work sometimes, we don't want the user to have false assumptions. **Instead [finalizers] usage is encouraged.**

[finalizers]: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#finalizers