### PR TITLE
Add controller queue length metrics

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -144,12 +144,17 @@ func New(cfg *Config) (Controller, error) {
 		cfg.ProcessingJobRetries,
 		workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 	)
-	queue = newMetricsBlockingQueue(
+
+	// Measure the queue.
+	queue, err = newMetricsBlockingQueue(
 		cfg.Name,
 		cfg.MetricsRecorder,
 		queue,
 		cfg.Logger,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("could not measure the queue: %w", err)
+	}
 
 	// store is the internal cache where objects will be store.
 	store := cache.Indexers{}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -246,8 +246,12 @@ func TestGenericControllerWithLeaderElection(t *testing.T) {
 			mh3 := &mcontroller.Handler{}
 
 			// Expect the calls on the lead (mh1) and no calls on the other ones.
+			var mu sync.Mutex
 			totalCalls := len(test.nsList.Items)
 			mh1.On("Handle", mock.Anything, mock.Anything).Return(nil).Times(totalCalls).Run(func(args mock.Arguments) {
+				mu.Lock()
+				defer mu.Unlock()
+
 				totalCalls--
 				// Check last call, if is the last call expected then stop the controller so
 				// we can assert the expectations of the calls and finish the test.

--- a/controller/metrics.go
+++ b/controller/metrics.go
@@ -14,13 +14,20 @@ type MetricsRecorder interface {
 	ObserveResourceInQueueDuration(ctx context.Context, controller string, queuedAt time.Time)
 	// ObserveResourceProcessingDuration measures how long it takes to process a resources (handling).
 	ObserveResourceProcessingDuration(ctx context.Context, controller string, success bool, startProcessingAt time.Time)
+	// RegisterResourceQueueLengthFunc will register a function that will be called
+	// by the metrics recorder to get the length of a queue at a given point in time.
+	RegisterResourceQueueLengthFunc(controller string, f func(context.Context) int) error
 }
 
 // DummyMetricsRecorder is a dummy metrics recorder.
 var DummyMetricsRecorder = dummy(0)
+var _ MetricsRecorder = DummyMetricsRecorder
 
 type dummy int
 
 func (dummy) IncResourceEventQueued(context.Context, string, bool)                       {}
 func (dummy) ObserveResourceInQueueDuration(context.Context, string, time.Time)          {}
 func (dummy) ObserveResourceProcessingDuration(context.Context, string, bool, time.Time) {}
+func (dummy) RegisterResourceQueueLengthFunc(controller string, f func(context.Context) int) error {
+	return nil
+}

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -31,6 +31,9 @@ func TestPrometheusRecorder(t *testing.T) {
 				r.IncResourceEventQueued(ctx, "ctrl3", false)
 			},
 			expMetrics: []string{
+				`# HELP kooper_controller_queued_events_total Total number of events queued.`,
+				`# TYPE kooper_controller_queued_events_total counter`,
+
 				`kooper_controller_queued_events_total{controller="ctrl1",requeue="false"} 2`,
 				`kooper_controller_queued_events_total{controller="ctrl2",requeue="false"} 1`,
 				`kooper_controller_queued_events_total{controller="ctrl3",requeue="false"} 1`,
@@ -50,6 +53,9 @@ func TestPrometheusRecorder(t *testing.T) {
 				r.ObserveResourceInQueueDuration(ctx, "ctrl2", t0.Add(-17*time.Millisecond))
 			},
 			expMetrics: []string{
+				`# HELP kooper_controller_event_in_queue_duration_seconds The duration of an event in the queue.`,
+				`# TYPE kooper_controller_event_in_queue_duration_seconds histogram`,
+
 				`kooper_controller_event_in_queue_duration_seconds_bucket{controller="ctrl1",le="0.005"} 0`,
 				`kooper_controller_event_in_queue_duration_seconds_bucket{controller="ctrl1",le="0.01"} 0`,
 				`kooper_controller_event_in_queue_duration_seconds_bucket{controller="ctrl1",le="0.025"} 0`,
@@ -95,6 +101,9 @@ func TestPrometheusRecorder(t *testing.T) {
 
 			},
 			expMetrics: []string{
+				`# HELP kooper_controller_event_in_queue_duration_seconds The duration of an event in the queue.`,
+				`# TYPE kooper_controller_event_in_queue_duration_seconds histogram`,
+
 				`kooper_controller_event_in_queue_duration_seconds_bucket{controller="ctrl1",le="10"} 1`,
 				`kooper_controller_event_in_queue_duration_seconds_bucket{controller="ctrl1",le="20"} 2`,
 				`kooper_controller_event_in_queue_duration_seconds_bucket{controller="ctrl1",le="30"} 3`,
@@ -116,6 +125,9 @@ func TestPrometheusRecorder(t *testing.T) {
 				r.ObserveResourceProcessingDuration(ctx, "ctrl2", false, t0.Add(-17*time.Millisecond))
 			},
 			expMetrics: []string{
+				`# HELP kooper_controller_processed_event_duration_seconds The duration for an event to be processed.`,
+				`# TYPE kooper_controller_processed_event_duration_seconds histogram`,
+
 				`kooper_controller_processed_event_duration_seconds_bucket{controller="ctrl1",success="true",le="0.005"} 0`,
 				`kooper_controller_processed_event_duration_seconds_bucket{controller="ctrl1",success="true",le="0.01"} 0`,
 				`kooper_controller_processed_event_duration_seconds_bucket{controller="ctrl1",success="true",le="0.025"} 0`,
@@ -174,12 +186,30 @@ func TestPrometheusRecorder(t *testing.T) {
 				r.ObserveResourceProcessingDuration(ctx, "ctrl1", true, t0.Add(-70*time.Second))
 			},
 			expMetrics: []string{
+				`# HELP kooper_controller_processed_event_duration_seconds The duration for an event to be processed.`,
+				`# TYPE kooper_controller_processed_event_duration_seconds histogram`,
 				`kooper_controller_processed_event_duration_seconds_bucket{controller="ctrl1",success="true",le="10"} 1`,
 				`kooper_controller_processed_event_duration_seconds_bucket{controller="ctrl1",success="true",le="20"} 2`,
 				`kooper_controller_processed_event_duration_seconds_bucket{controller="ctrl1",success="true",le="30"} 3`,
 				`kooper_controller_processed_event_duration_seconds_bucket{controller="ctrl1",success="true",le="50"} 3`,
 				`kooper_controller_processed_event_duration_seconds_bucket{controller="ctrl1",success="true",le="+Inf"} 5`,
 				`kooper_controller_processed_event_duration_seconds_count{controller="ctrl1",success="true"} 5`,
+			},
+		},
+
+		"Registering resource queue lenght function should measure the size of the queue.": {
+			cfg: kooperprometheus.Config{},
+			addMetrics: func(r *kooperprometheus.Recorder) {
+				_ = r.RegisterResourceQueueLengthFunc("ctrl1", func(_ context.Context) int { return 42 })
+				_ = r.RegisterResourceQueueLengthFunc("ctrl2", func(_ context.Context) int { return 142 })
+				_ = r.RegisterResourceQueueLengthFunc("ctrl3", func(_ context.Context) int { return 242 })
+			},
+			expMetrics: []string{
+				`# HELP kooper_controller_event_queue_length Length of the controller resource queue.`,
+				`# TYPE kooper_controller_event_queue_length gauge`,
+				`kooper_controller_event_queue_length{controller="ctrl1"} 42`,
+				`kooper_controller_event_queue_length{controller="ctrl2"} 142`,
+				`kooper_controller_event_queue_length{controller="ctrl3"} 242`,
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds measuring the length of the controller queue. It uses a callback mode, we need to register a function on the metrics recorder that will return the size of the queue.

It comes with the Prometheus implementation.